### PR TITLE
change facets to be addressed as strings rather than numbers

### DIFF
--- a/src/sections/Facet/Facet.js
+++ b/src/sections/Facet/Facet.js
@@ -9,13 +9,27 @@ class Facet extends React.Component {
     facets: PropTypes.object.isRequired
   };
 
+  keyToCorrectString = key => {
+    switch(key) {
+      case 0:
+        return "prediction"
+      case 1:
+        return "dataPoints"
+      case 2:
+        return "marginals"
+      case 3:
+        return "density"
+    }
+  }
+
   handleDataClick = key => {
-    this.props.onFacetDataUpdate(key);
+    this.props.onFacetDataUpdate(this.keyToCorrectString(key));
   };
 
   handleModelClick = key => {
-    this.props.onFacetModelUpdate(key);
+    this.props.onFacetModelUpdate(this.keyToCorrectString(key));
   };
+
 
   render(){
     const { facetsActions } = specificationFacetConfig;
@@ -27,10 +41,15 @@ class Facet extends React.Component {
           <div className="facet-label">
             <div>
               <img src={item.icon} alt="" />
-              {item.name}<input type="checkbox" onClick={() => this.handleModelClick(key)}
-                                checked={facets[key].model}
-            /><input type="checkbox" onClick={() => this.handleDataClick(key)}
-                     checked={facets[key].data}
+              {item.name}<input
+              type="checkbox"
+              onClick={() => this.handleModelClick(key)}
+              checked={facets[this.keyToCorrectString(key)].model}
+            /><input
+              type="checkbox"
+              onClick={() => this.handleDataClick(key)}
+              checked={facets[this.keyToCorrectString(key)].data}
+
             />
             </div>
           </div>

--- a/src/sections/Facet/FacetContainer.js
+++ b/src/sections/Facet/FacetContainer.js
@@ -16,15 +16,16 @@ class FacetContainer extends React.Component {
     );
   }
 
-  updateFacetData = (isBoxChecked) => {
+  updateFacetData = (key) => {
     const { changeFacets } = this.props;
-    changeFacets(isBoxChecked, "data");
+    changeFacets(key, "data");
   };
 
-  updateFacetModel = (isBoxChecked) => {
+  updateFacetModel = (key) => {
     const { changeFacets } = this.props;
-    changeFacets(isBoxChecked, "model");
+    changeFacets(key, "model");
   };
+
 }
 
 const mapStateToProps = (state) => {
@@ -35,8 +36,8 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    changeFacets: (isBoxChecked, type) =>
-      dispatch(updateFacetState({ type: type, key: isBoxChecked })),
+    changeFacets: (key, type) =>
+      dispatch(updateFacetState({ type: type, key: key })),
   };
 };
 

--- a/src/states/model/reducer.js
+++ b/src/states/model/reducer.js
@@ -17,19 +17,19 @@ export const defaultState = {
     Size: new Set([]),
   },
   facets: {
-    0: {
+    "prediction": {
       model: false,
       data: false,
     },
-    1: {
+    "dataPoints": {
       model: false,
       data: true,
     },
-    2: {
+    "marginals": {
       model: false,
       data: true,
     },
-    3: {
+    "density": {
       model: false,
       data: false,
     },


### PR DESCRIPTION
The different facets are now addressable as strings "predicition", "dataPoints", "marginals", and "density" rather than 0-3 