### PR TITLE
fixing #39

### DIFF
--- a/src/components/RnDPlotWrapper/RnDPlotWrapper.js
+++ b/src/components/RnDPlotWrapper/RnDPlotWrapper.js
@@ -26,6 +26,13 @@ class RnDPlotWrapper extends Component {
     plotWindowsPosY: 50,
   };
 
+  onClickEvent = () =>  {
+    const { id, onActivePlotChange, activePlotId } = this.props;
+    if (id !== activePlotId) {
+      onActivePlotChange(id);
+    }
+  }
+
   setNewPos = (dragIndex) => {
     this.setState({
       plotWindowsPosX: dragIndex.x,
@@ -74,6 +81,7 @@ class RnDPlotWrapper extends Component {
 
     return (
       <Rnd
+        onClick={this.onClickEvent}
         size={{ width: plotWindowsWidth, height: plotWindowsHeight }}
         position={{ x: plotWindowsPosX, y: plotWindowsPosY }}
         cancel=".cancel"

--- a/src/index.js
+++ b/src/index.js
@@ -13,4 +13,4 @@ ReactDOM.render(<App />, document.getElementById('root'));
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.
 // Learn more about service workers: https://bit.ly/CRA-PWA
-serviceWorker.unregister();
+serviceWorker.register();

--- a/src/index.js
+++ b/src/index.js
@@ -13,4 +13,4 @@ ReactDOM.render(<App />, document.getElementById('root'));
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.
 // Learn more about service workers: https://bit.ly/CRA-PWA
-serviceWorker.register();
+serviceWorker.unregister();


### PR DESCRIPTION
Should fix issue #39 that the active plot is only updated when clicking on the upper border. Now, every click on a plot should make it the activePlot and bring it up front.